### PR TITLE
extend interface to enable logging with context

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,15 +18,23 @@ To implement another logger is straight forward. Write your own adapter that imp
 ```go
 type Logger interface {
   Error(msg string)
+  ErrorWithFields(fields map[string]interface{}, msg string)
   Errorf(format string, v ...interface{})
+  ErrorfWithFields(fields map[string]interface{}, format string, v ...interface{})
   ErrorErr(err error)
   Warn(msg string)
+  WarnWithFields(fields map[string]interface{}, msg string)
   Warnf(format string, v ...interface{})
+  WarnfWithFields(fields map[string]interface{}, format string, v ...interface{})
   WarnErr(err error)
   Info(msg string)
+  InfoWithFields(fields map[string]interface{}, msg string)
   Infof(format string, v ...interface{})
+  InfofWithFields(fields map[string]interface{}, format string, v ...interface{})
   Debug(msg string)
+  DebugWithFields(fields map[string]interface{}, msg string)
   Debugf(format string, v ...interface{})
+  DebugfWithFields(fields map[string]interface{}, format string, v ...interface{})
 }
 ```
 
@@ -73,16 +81,28 @@ Finally, you can decouple the logger implementation by using the `Logger` interf
 ```go
 func doSomething(l logger.Logger) {
   err := errors.New("some error")
+  fields := map[string]interface{}{
+    "key": "value",
+  }
+
   l.Error("a meaningful std message")
+  l.ErrorWithFields(fields, "a meaningful std message")
   l.Errorf("a meaningful std message: %v", err)
+  l.ErrorfWithFields(fields, "a meaningful std message: %v", err)
   l.ErrorErr(err)
   l.Warn("a meaningful std message")
+  l.WarnWithFields(fields, "a meaningful std message")
   l.Warnf("a meaningful std message: %v", err)
+  l.WarnfWithFields(fields, "a meaningful std message: %v", err)
   l.WarnErr(err)
   l.Info("a meaningful std message")
+  l.InfoWithFields(fields, "a meaningful std message")
   l.Infof("a meaningful std message: %v", err)
+  l.InfofWithFields(fields, "a meaningful std message: %v", err)
   l.Debug("a meaningful std message")
+  l.DebugWithFields(fields, "a meaningful std message")
   l.Debugf("a meaningful std message: %v", err)
+  l.DebugfWithFields(fields, "a meaningful std message: %v", err)
 }
 ```
 

--- a/adapter/std/adapter.go
+++ b/adapter/std/adapter.go
@@ -1,6 +1,7 @@
 package std
 
 import (
+	"fmt"
 	"log"
 )
 
@@ -25,8 +26,16 @@ func (l *stdLogAdapter) Error(msg string) {
 	l.innerLogger.Println(LevelError + " " + msg)
 }
 
+func (l *stdLogAdapter) ErrorWithFields(fields map[string]interface{}, msg string) {
+	l.innerLogger.Println(LevelError + " " + fmt.Sprint(fields) + " " + msg)
+}
+
 func (l *stdLogAdapter) Errorf(format string, v ...interface{}) {
 	l.innerLogger.Printf(LevelError+" "+format, v...)
+}
+
+func (l *stdLogAdapter) ErrorfWithFields(fields map[string]interface{}, format string, v ...interface{}) {
+	l.innerLogger.Printf(LevelError+" "+fmt.Sprint(fields)+" "+format, v...)
 }
 
 func (l *stdLogAdapter) ErrorErr(err error) {
@@ -37,8 +46,16 @@ func (l *stdLogAdapter) Warn(msg string) {
 	l.innerLogger.Println(LevelWarn + " " + msg)
 }
 
+func (l *stdLogAdapter) WarnWithFields(fields map[string]interface{}, msg string) {
+	l.innerLogger.Println(LevelWarn + " " + fmt.Sprint(fields) + " " + msg)
+}
+
 func (l *stdLogAdapter) Warnf(format string, v ...interface{}) {
 	l.innerLogger.Printf(LevelWarn+" "+format, v...)
+}
+
+func (l *stdLogAdapter) WarnfWithFields(fields map[string]interface{}, format string, v ...interface{}) {
+	l.innerLogger.Printf(LevelWarn+" "+fmt.Sprint(fields)+" "+format, v...)
 }
 
 func (l *stdLogAdapter) WarnErr(err error) {
@@ -49,14 +66,30 @@ func (l *stdLogAdapter) Info(msg string) {
 	l.innerLogger.Println(LevelInfo + " " + msg)
 }
 
+func (l *stdLogAdapter) InfoWithFields(fields map[string]interface{}, msg string) {
+	l.innerLogger.Println(LevelInfo + " " + fmt.Sprint(fields) + " " + msg)
+}
+
 func (l *stdLogAdapter) Infof(format string, v ...interface{}) {
 	l.innerLogger.Printf(LevelInfo+" "+format, v...)
+}
+
+func (l *stdLogAdapter) InfofWithFields(fields map[string]interface{}, format string, v ...interface{}) {
+	l.innerLogger.Printf(LevelInfo+" "+fmt.Sprint(fields)+" "+format, v...)
 }
 
 func (l *stdLogAdapter) Debug(msg string) {
 	l.innerLogger.Println(LevelDebug + " " + msg)
 }
 
+func (l *stdLogAdapter) DebugWithFields(fields map[string]interface{}, msg string) {
+	l.innerLogger.Println(LevelDebug + " " + fmt.Sprint(fields) + " " + msg)
+}
+
 func (l *stdLogAdapter) Debugf(format string, v ...interface{}) {
 	l.innerLogger.Printf(LevelDebug+" "+format, v...)
+}
+
+func (l *stdLogAdapter) DebugfWithFields(fields map[string]interface{}, format string, v ...interface{}) {
+	l.innerLogger.Printf(LevelDebug+" "+fmt.Sprint(fields)+" "+format, v...)
 }

--- a/adapter/std/adapter_test.go
+++ b/adapter/std/adapter_test.go
@@ -27,6 +27,19 @@ func TestStdLogAdapter_Error(t *testing.T) {
 	})
 }
 
+func TestStdLogAdapter_ErrorWithFields(t *testing.T) {
+	t.Run("TestStdLogAdapter_ErrorWithFields_ShouldLog", func(t *testing.T) {
+		expectedMsg := "error message"
+		expectedFields := map[string]interface{}{
+			"key": "value",
+		}
+		adapter, out := newAdapter()
+		adapter.ErrorWithFields(expectedFields, expectedMsg)
+
+		assert.Contains(t, out.String(), LevelError+" map[key:value] error message\n")
+	})
+}
+
 func TestStdLogAdapter_Errorf(t *testing.T) {
 	t.Run("TestStdLogAdapter_Errorf_ShouldLog", func(t *testing.T) {
 		expectedMsg := "error message: %v"
@@ -34,6 +47,19 @@ func TestStdLogAdapter_Errorf(t *testing.T) {
 		adapter.Errorf(expectedMsg, errors.New("some error"))
 
 		assert.Contains(t, out.String(), LevelError+" error message: some error\n")
+	})
+}
+
+func TestStdLogAdapter_ErrorfWithFields(t *testing.T) {
+	t.Run("TestStdLogAdapter_ErrorfWithFields_ShouldLog", func(t *testing.T) {
+		expectedMsg := "error message: %v"
+		expectedFields := map[string]interface{}{
+			"key": "value",
+		}
+		adapter, out := newAdapter()
+		adapter.ErrorfWithFields(expectedFields, expectedMsg, errors.New("some error"))
+
+		assert.Contains(t, out.String(), LevelError+" map[key:value] error message: some error\n")
 	})
 }
 
@@ -63,6 +89,19 @@ func TestStdLogAdapter_Warn(t *testing.T) {
 	})
 }
 
+func TestStdLogAdapter_WarnWithFields(t *testing.T) {
+	t.Run("TestStdLogAdapter_WarnWithFields_ShouldLog", func(t *testing.T) {
+		expectedMsg := "warning message"
+		expectedFields := map[string]interface{}{
+			"key": "value",
+		}
+		adapter, out := newAdapter()
+		adapter.WarnWithFields(expectedFields, expectedMsg)
+
+		assert.Contains(t, out.String(), LevelWarn+" map[key:value] warning message\n")
+	})
+}
+
 func TestStdLogAdapter_Warnf(t *testing.T) {
 	t.Run("TestStdLogAdapter_Warnf_ShouldLog", func(t *testing.T) {
 		expectedMsg := "warning message: %v"
@@ -70,6 +109,19 @@ func TestStdLogAdapter_Warnf(t *testing.T) {
 		adapter.Warnf(expectedMsg, errors.New("some error"))
 
 		assert.Contains(t, out.String(), LevelWarn+" warning message: some error\n")
+	})
+}
+
+func TestStdLogAdapter_WarnfWithFields(t *testing.T) {
+	t.Run("TestStdLogAdapter_WarnfWithFields_ShouldLog", func(t *testing.T) {
+		expectedMsg := "warning message: %v"
+		expectedFields := map[string]interface{}{
+			"key": "value",
+		}
+		adapter, out := newAdapter()
+		adapter.WarnfWithFields(expectedFields, expectedMsg, errors.New("some error"))
+
+		assert.Contains(t, out.String(), LevelWarn+" map[key:value] warning message: some error\n")
 	})
 }
 
@@ -92,6 +144,19 @@ func TestStdLogAdapter_Info(t *testing.T) {
 	})
 }
 
+func TestStdLogAdapter_InfoWithFields(t *testing.T) {
+	t.Run("TestStdLogAdapter_InfoWithFields_ShouldLog", func(t *testing.T) {
+		expectedMsg := "info message"
+		expectedFields := map[string]interface{}{
+			"key": "value",
+		}
+		adapter, out := newAdapter()
+		adapter.InfoWithFields(expectedFields, expectedMsg)
+
+		assert.Contains(t, out.String(), LevelInfo+" map[key:value] info message\n")
+	})
+}
+
 func TestStdLogAdapter_Infof(t *testing.T) {
 	t.Run("TestStdLogAdapter_Infof_ShouldLog", func(t *testing.T) {
 		expectedMsg := "info message: %v"
@@ -99,6 +164,19 @@ func TestStdLogAdapter_Infof(t *testing.T) {
 		adapter.Infof(expectedMsg, errors.New("some error"))
 
 		assert.Contains(t, out.String(), LevelInfo+" info message: some error\n")
+	})
+}
+
+func TestStdLogAdapter_InfofWithFields(t *testing.T) {
+	t.Run("TestStdLogAdapter_InfofWithFields_ShouldLog", func(t *testing.T) {
+		expectedMsg := "info message: %v"
+		expectedFields := map[string]interface{}{
+			"key": "value",
+		}
+		adapter, out := newAdapter()
+		adapter.InfofWithFields(expectedFields, expectedMsg, errors.New("some error"))
+
+		assert.Contains(t, out.String(), LevelInfo+" map[key:value] info message: some error\n")
 	})
 }
 
@@ -112,6 +190,19 @@ func TestStdLogAdapter_Debug(t *testing.T) {
 	})
 }
 
+func TestStdLogAdapter_DebugWithFields(t *testing.T) {
+	t.Run("TestStdLogAdapter_DebugWithFields_ShouldLog", func(t *testing.T) {
+		expectedMsg := "debug message"
+		expectedFields := map[string]interface{}{
+			"key": "value",
+		}
+		adapter, out := newAdapter()
+		adapter.DebugWithFields(expectedFields, expectedMsg)
+
+		assert.Contains(t, out.String(), LevelDebug+" map[key:value] debug message\n")
+	})
+}
+
 func TestStdLogAdapter_Debugf(t *testing.T) {
 	t.Run("TestStdLogAdapter_Debugf_ShouldLog", func(t *testing.T) {
 		expectedMsg := "debug message: %v"
@@ -119,6 +210,19 @@ func TestStdLogAdapter_Debugf(t *testing.T) {
 		adapter.Debugf(expectedMsg, errors.New("some error"))
 
 		assert.Contains(t, out.String(), LevelDebug+" debug message: some error\n")
+	})
+}
+
+func TestStdLogAdapter_DebugfWithFields(t *testing.T) {
+	t.Run("TestStdLogAdapter_DebugfWithFields_ShouldLog", func(t *testing.T) {
+		expectedMsg := "debug message: %v"
+		expectedFields := map[string]interface{}{
+			"key": "value",
+		}
+		adapter, out := newAdapter()
+		adapter.DebugfWithFields(expectedFields, expectedMsg, errors.New("some error"))
+
+		assert.Contains(t, out.String(), LevelDebug+" map[key:value] debug message: some error\n")
 	})
 }
 

--- a/adapter/std/example/main.go
+++ b/adapter/std/example/main.go
@@ -14,15 +14,26 @@ func main() {
 
 func doSomething(l logger.Logger) {
 	err := errors.New("some error")
+	fields := map[string]interface{}{
+		"key": "value",
+	}
 
 	l.Error("a meaningful std message")
+	l.ErrorWithFields(fields, "a meaningful std message")
 	l.Errorf("a meaningful std message: %v", err)
+	l.ErrorfWithFields(fields, "a meaningful std message: %v", err)
 	l.ErrorErr(err)
 	l.Warn("a meaningful std message")
+	l.WarnWithFields(fields, "a meaningful std message")
 	l.Warnf("a meaningful std message: %v", err)
+	l.WarnfWithFields(fields, "a meaningful std message: %v", err)
 	l.WarnErr(err)
 	l.Info("a meaningful std message")
+	l.InfoWithFields(fields, "a meaningful std message")
 	l.Infof("a meaningful std message: %v", err)
+	l.InfofWithFields(fields, "a meaningful std message: %v", err)
 	l.Debug("a meaningful std message")
+	l.DebugWithFields(fields, "a meaningful std message")
 	l.Debugf("a meaningful std message: %v", err)
+	l.DebugfWithFields(fields, "a meaningful std message: %v", err)
 }

--- a/adapter/zap/adapter.go
+++ b/adapter/zap/adapter.go
@@ -15,12 +15,28 @@ func NewAdapter(zap *zap.Logger) *zapAdapter {
 	}
 }
 
+func createZapFieldSlice(fields map[string]interface{}) []zap.Field {
+	zapFields := make([]zap.Field, 0)
+	for key, val := range fields {
+		zapFields = append(zapFields, zap.Any(key, val))
+	}
+	return zapFields
+}
+
 func (l *zapAdapter) Error(msg string) {
 	l.innerLogger.Error(msg)
 }
 
+func (l *zapAdapter) ErrorWithFields(fields map[string]interface{}, msg string) {
+	l.innerLogger.Error(msg, createZapFieldSlice(fields)...)
+}
+
 func (l *zapAdapter) Errorf(format string, v ...interface{}) {
 	l.innerLogger.Error(fmt.Sprintf(format, v...))
+}
+
+func (l *zapAdapter) ErrorfWithFields(fields map[string]interface{}, format string, v ...interface{}) {
+	l.innerLogger.Error(fmt.Sprintf(format, v...), createZapFieldSlice(fields)...)
 }
 
 func (l *zapAdapter) ErrorErr(err error) {
@@ -31,8 +47,16 @@ func (l *zapAdapter) Warn(msg string) {
 	l.innerLogger.Warn(msg)
 }
 
+func (l *zapAdapter) WarnWithFields(fields map[string]interface{}, msg string) {
+	l.innerLogger.Warn(msg, createZapFieldSlice(fields)...)
+}
+
 func (l *zapAdapter) Warnf(format string, v ...interface{}) {
 	l.innerLogger.Warn(fmt.Sprintf(format, v...))
+}
+
+func (l *zapAdapter) WarnfWithFields(fields map[string]interface{}, format string, v ...interface{}) {
+	l.innerLogger.Warn(fmt.Sprintf(format, v...), createZapFieldSlice(fields)...)
 }
 
 func (l *zapAdapter) WarnErr(err error) {
@@ -43,14 +67,30 @@ func (l *zapAdapter) Info(msg string) {
 	l.innerLogger.Info(msg)
 }
 
+func (l *zapAdapter) InfoWithFields(fields map[string]interface{}, msg string) {
+	l.innerLogger.Info(msg, createZapFieldSlice(fields)...)
+}
+
 func (l *zapAdapter) Infof(format string, v ...interface{}) {
 	l.innerLogger.Info(fmt.Sprintf(format, v...))
+}
+
+func (l *zapAdapter) InfofWithFields(fields map[string]interface{}, format string, v ...interface{}) {
+	l.innerLogger.Info(fmt.Sprintf(format, v...), createZapFieldSlice(fields)...)
 }
 
 func (l *zapAdapter) Debug(msg string) {
 	l.innerLogger.Debug(msg)
 }
 
+func (l *zapAdapter) DebugWithFields(fields map[string]interface{}, msg string) {
+	l.innerLogger.Debug(msg, createZapFieldSlice(fields)...)
+}
+
 func (l *zapAdapter) Debugf(format string, v ...interface{}) {
 	l.innerLogger.Debug(fmt.Sprintf(format, v...))
+}
+
+func (l *zapAdapter) DebugfWithFields(fields map[string]interface{}, format string, v ...interface{}) {
+	l.innerLogger.Debug(fmt.Sprintf(format, v...), createZapFieldSlice(fields)...)
 }

--- a/adapter/zap/adapter_test.go
+++ b/adapter/zap/adapter_test.go
@@ -28,6 +28,20 @@ func TestStdLogAdapter_Error(t *testing.T) {
 	})
 }
 
+func TestStdLogAdapter_ErrorWithFields(t *testing.T) {
+	t.Run("TestStdLogAdapter_ErrorWithFields_ShouldLog", func(t *testing.T) {
+		expectedMsg := "error message"
+		expectedFields := map[string]interface{}{
+			"key": "value",
+		}
+		adapter, out := newAdapter()
+		adapter.ErrorWithFields(expectedFields, expectedMsg)
+
+		assert.Contains(t, out.String(), `"msg":"error message"`)
+		assert.Contains(t, out.String(), `"key":"value"`)
+	})
+}
+
 func TestStdLogAdapter_Errorf(t *testing.T) {
 	t.Run("TestStdLogAdapter_Errorf_ShouldLog", func(t *testing.T) {
 		expectedMsg := "error message: %v"
@@ -35,6 +49,20 @@ func TestStdLogAdapter_Errorf(t *testing.T) {
 		adapter.Errorf(expectedMsg, errors.New("some error"))
 
 		assert.Contains(t, out.String(), `"msg":"error message: some error"`)
+	})
+}
+
+func TestStdLogAdapter_ErrorfWithFields(t *testing.T) {
+	t.Run("TestStdLogAdapter_ErrorfWithFields_ShouldLog", func(t *testing.T) {
+		expectedMsg := "error message: %v"
+		expectedFields := map[string]interface{}{
+			"key": "value",
+		}
+		adapter, out := newAdapter()
+		adapter.ErrorfWithFields(expectedFields, expectedMsg, errors.New("some error"))
+
+		assert.Contains(t, out.String(), `"msg":"error message: some error"`)
+		assert.Contains(t, out.String(), `"key":"value"`)
 	})
 }
 
@@ -68,6 +96,20 @@ func TestStdLogAdapter_Warn(t *testing.T) {
 	})
 }
 
+func TestStdLogAdapter_WarnWithFields(t *testing.T) {
+	t.Run("TestStdLogAdapter_WarnWithFields_ShouldLog", func(t *testing.T) {
+		expectedMsg := "warning message"
+		expectedFields := map[string]interface{}{
+			"key": "value",
+		}
+		adapter, out := newAdapter()
+		adapter.WarnWithFields(expectedFields, expectedMsg)
+
+		assert.Contains(t, out.String(), `"msg":"warning message"`)
+		assert.Contains(t, out.String(), `"key":"value"`)
+	})
+}
+
 func TestStdLogAdapter_Warnf(t *testing.T) {
 	t.Run("TestStdLogAdapter_Warnf_ShouldLog", func(t *testing.T) {
 		expectedMsg := "warning message: %v"
@@ -75,6 +117,20 @@ func TestStdLogAdapter_Warnf(t *testing.T) {
 		adapter.Warnf(expectedMsg, errors.New("some error"))
 
 		assert.Contains(t, out.String(), `"msg":"warning message: some error"`)
+	})
+}
+
+func TestStdLogAdapter_WarnfWithFields(t *testing.T) {
+	t.Run("TestStdLogAdapter_WarnfWithFields_ShouldLog", func(t *testing.T) {
+		expectedMsg := "warning message: %v"
+		expectedFields := map[string]interface{}{
+			"key": "value",
+		}
+		adapter, out := newAdapter()
+		adapter.WarnfWithFields(expectedFields, expectedMsg, errors.New("some error"))
+
+		assert.Contains(t, out.String(), `"msg":"warning message: some error"`)
+		assert.Contains(t, out.String(), `"key":"value"`)
 	})
 }
 
@@ -99,6 +155,20 @@ func TestStdLogAdapter_Info(t *testing.T) {
 	})
 }
 
+func TestStdLogAdapter_InfoWithFields(t *testing.T) {
+	t.Run("TestStdLogAdapter_InfoWithFields_ShouldLog", func(t *testing.T) {
+		expectedMsg := "info message"
+		expectedFields := map[string]interface{}{
+			"key": "value",
+		}
+		adapter, out := newAdapter()
+		adapter.InfoWithFields(expectedFields, expectedMsg)
+
+		assert.Contains(t, out.String(), `"msg":"info message"`)
+		assert.Contains(t, out.String(), `"key":"value"`)
+	})
+}
+
 func TestStdLogAdapter_Infof(t *testing.T) {
 	t.Run("TestStdLogAdapter_Infof_ShouldLog", func(t *testing.T) {
 		expectedMsg := "info message: %v"
@@ -106,6 +176,20 @@ func TestStdLogAdapter_Infof(t *testing.T) {
 		adapter.Infof(expectedMsg, errors.New("some error"))
 
 		assert.Contains(t, out.String(), `"msg":"info message: some error"`)
+	})
+}
+
+func TestStdLogAdapter_InfofWithFields(t *testing.T) {
+	t.Run("TestStdLogAdapter_InfofWithFields_ShouldLog", func(t *testing.T) {
+		expectedMsg := "info message: %v"
+		expectedFields := map[string]interface{}{
+			"key": "value",
+		}
+		adapter, out := newAdapter()
+		adapter.InfofWithFields(expectedFields, expectedMsg, errors.New("some error"))
+
+		assert.Contains(t, out.String(), `"msg":"info message: some error"`)
+		assert.Contains(t, out.String(), `"key":"value"`)
 	})
 }
 
@@ -119,6 +203,20 @@ func TestStdLogAdapter_Debug(t *testing.T) {
 	})
 }
 
+func TestStdLogAdapter_DebugWithFields(t *testing.T) {
+	t.Run("TestStdLogAdapter_DebugWithFields_ShouldLog", func(t *testing.T) {
+		expectedMsg := "debug message"
+		expectedFields := map[string]interface{}{
+			"key": "value",
+		}
+		adapter, out := newAdapter()
+		adapter.DebugWithFields(expectedFields, expectedMsg)
+
+		assert.Contains(t, out.String(), `"msg":"debug message"`)
+		assert.Contains(t, out.String(), `"key":"value"`)
+	})
+}
+
 func TestStdLogAdapter_Debugf(t *testing.T) {
 	t.Run("TestStdLogAdapter_Debugf_ShouldLog", func(t *testing.T) {
 		expectedMsg := "debug message: %v"
@@ -126,6 +224,20 @@ func TestStdLogAdapter_Debugf(t *testing.T) {
 		adapter.Debugf(expectedMsg, errors.New("some error"))
 
 		assert.Contains(t, out.String(), `"msg":"debug message: some error"`)
+	})
+}
+
+func TestStdLogAdapter_DebugfWithFields(t *testing.T) {
+	t.Run("TestStdLogAdapter_DebugfWithFields_ShouldLog", func(t *testing.T) {
+		expectedMsg := "debug message: %v"
+		expectedFields := map[string]interface{}{
+			"key": "value",
+		}
+		adapter, out := newAdapter()
+		adapter.DebugfWithFields(expectedFields, expectedMsg, errors.New("some error"))
+
+		assert.Contains(t, out.String(), `"msg":"debug message: some error"`)
+		assert.Contains(t, out.String(), `"key":"value"`)
 	})
 }
 

--- a/adapter/zap/example/main.go
+++ b/adapter/zap/example/main.go
@@ -17,15 +17,26 @@ func main() {
 
 func doSomething(l logger.Logger) {
 	err := errors.New("some error")
+	fields := map[string]interface{}{
+		"key": "value",
+	}
 
 	l.Error("a meaningful std message")
+	l.ErrorWithFields(fields, "a meaningful std message")
 	l.Errorf("a meaningful std message: %v", err)
+	l.ErrorfWithFields(fields, "a meaningful std message: %v", err)
 	l.ErrorErr(err)
 	l.Warn("a meaningful std message")
+	l.WarnWithFields(fields, "a meaningful std message")
 	l.Warnf("a meaningful std message: %v", err)
+	l.WarnfWithFields(fields, "a meaningful std message: %v", err)
 	l.WarnErr(err)
 	l.Info("a meaningful std message")
+	l.InfoWithFields(fields, "a meaningful std message")
 	l.Infof("a meaningful std message: %v", err)
+	l.InfofWithFields(fields, "a meaningful std message: %v", err)
 	l.Debug("a meaningful std message")
+	l.DebugWithFields(fields, "a meaningful std message")
 	l.Debugf("a meaningful std message: %v", err)
+	l.DebugfWithFields(fields, "a meaningful std message: %v", err)
 }

--- a/adapter/zlog/adapter.go
+++ b/adapter/zlog/adapter.go
@@ -18,8 +18,16 @@ func (l *zerologAdapter) Error(msg string) {
 	l.innerLogger.Error().Msg(msg)
 }
 
+func (l *zerologAdapter) ErrorWithFields(fields map[string]interface{}, msg string) {
+	l.innerLogger.Error().Fields(fields).Msg(msg)
+}
+
 func (l *zerologAdapter) Errorf(format string, v ...interface{}) {
 	l.innerLogger.Error().Msgf(format, v...)
+}
+
+func (l *zerologAdapter) ErrorfWithFields(fields map[string]interface{}, format string, v ...interface{}) {
+	l.innerLogger.Error().Fields(fields).Msgf(format, v...)
 }
 
 func (l *zerologAdapter) ErrorErr(err error) {
@@ -30,8 +38,16 @@ func (l *zerologAdapter) Warn(msg string) {
 	l.innerLogger.Warn().Msg(msg)
 }
 
+func (l *zerologAdapter) WarnWithFields(fields map[string]interface{}, msg string) {
+	l.innerLogger.Warn().Fields(fields).Msg(msg)
+}
+
 func (l *zerologAdapter) Warnf(format string, v ...interface{}) {
 	l.innerLogger.Warn().Msgf(format, v...)
+}
+
+func (l *zerologAdapter) WarnfWithFields(fields map[string]interface{}, format string, v ...interface{}) {
+	l.innerLogger.Warn().Fields(fields).Msgf(format, v...)
 }
 
 func (l *zerologAdapter) WarnErr(err error) {
@@ -42,14 +58,30 @@ func (l *zerologAdapter) Info(msg string) {
 	l.innerLogger.Info().Msg(msg)
 }
 
+func (l *zerologAdapter) InfoWithFields(fields map[string]interface{}, msg string) {
+	l.innerLogger.Info().Fields(fields).Msg(msg)
+}
+
 func (l *zerologAdapter) Infof(format string, v ...interface{}) {
 	l.innerLogger.Info().Msgf(format, v...)
+}
+
+func (l *zerologAdapter) InfofWithFields(fields map[string]interface{}, format string, v ...interface{}) {
+	l.innerLogger.Info().Fields(fields).Msgf(format, v...)
 }
 
 func (l *zerologAdapter) Debug(msg string) {
 	l.innerLogger.Debug().Msg(msg)
 }
 
+func (l *zerologAdapter) DebugWithFields(fields map[string]interface{}, msg string) {
+	l.innerLogger.Debug().Fields(fields).Msg(msg)
+}
+
 func (l *zerologAdapter) Debugf(format string, v ...interface{}) {
 	l.innerLogger.Debug().Msgf(format, v...)
+}
+
+func (l *zerologAdapter) DebugfWithFields(fields map[string]interface{}, format string, v ...interface{}) {
+	l.innerLogger.Debug().Fields(fields).Msgf(format, v...)
 }

--- a/adapter/zlog/adapter_test.go
+++ b/adapter/zlog/adapter_test.go
@@ -28,6 +28,19 @@ func TestZerologAdapter_Error(t *testing.T) {
 	})
 }
 
+func TestZerologAdapter_ErrorWithFields(t *testing.T) {
+	t.Run("TestZerologAdapter_ErrorWithFields_ShouldLog", func(t *testing.T) {
+		expectedMsg := "error message"
+		expectedFields := map[string]interface{}{
+			"key": "value",
+		}
+		adapter, out := newAdapter()
+		adapter.ErrorWithFields(expectedFields, expectedMsg)
+
+		assert.Equal(t, "{\"level\":\"error\",\"key\":\"value\",\"message\":\"error message\"}\n", out.String())
+	})
+}
+
 func TestZerologAdapter_Errorf(t *testing.T) {
 	t.Run("TestZerologAdapter_Errorf_ShouldLog", func(t *testing.T) {
 		expectedMsg := "error message: %v"
@@ -35,6 +48,19 @@ func TestZerologAdapter_Errorf(t *testing.T) {
 		adapter.Errorf(expectedMsg, errors.New("some error"))
 
 		assert.Equal(t, "{\"level\":\"error\",\"message\":\"error message: some error\"}\n", out.String())
+	})
+}
+
+func TestZerologAdapter_ErrorfWithFields(t *testing.T) {
+	t.Run("TestZerologAdapter_ErrorfWithFields_ShouldLog", func(t *testing.T) {
+		expectedMsg := "error message: %v"
+		expectedFields := map[string]interface{}{
+			"key": "value",
+		}
+		adapter, out := newAdapter()
+		adapter.ErrorfWithFields(expectedFields, expectedMsg, errors.New("some error"))
+
+		assert.Equal(t, "{\"level\":\"error\",\"key\":\"value\",\"message\":\"error message: some error\"}\n", out.String())
 	})
 }
 
@@ -70,6 +96,19 @@ func TestZerologAdapter_Warn(t *testing.T) {
 	})
 }
 
+func TestZerologAdapter_WarnWithFields(t *testing.T) {
+	t.Run("TestZerologAdapter_WarnWithFields_ShouldLog", func(t *testing.T) {
+		expectedMsg := "warning message"
+		expectedFields := map[string]interface{}{
+			"key": "value",
+		}
+		adapter, out := newAdapter()
+		adapter.WarnWithFields(expectedFields, expectedMsg)
+
+		assert.Equal(t, "{\"level\":\"warn\",\"key\":\"value\",\"message\":\"warning message\"}\n", out.String())
+	})
+}
+
 func TestZerologAdapter_Warnf(t *testing.T) {
 	t.Run("TestZerologAdapter_Warnf_ShouldLog", func(t *testing.T) {
 		expectedMsg := "warning message: %v"
@@ -77,6 +116,19 @@ func TestZerologAdapter_Warnf(t *testing.T) {
 		adapter.Warnf(expectedMsg, errors.New("some error"))
 
 		assert.Equal(t, "{\"level\":\"warn\",\"message\":\"warning message: some error\"}\n", out.String())
+	})
+}
+
+func TestZerologAdapter_WarnfWithFields(t *testing.T) {
+	t.Run("TestZerologAdapter_WarnfWithFields_ShouldLog", func(t *testing.T) {
+		expectedMsg := "warning message: %v"
+		expectedFields := map[string]interface{}{
+			"key": "value",
+		}
+		adapter, out := newAdapter()
+		adapter.WarnfWithFields(expectedFields, expectedMsg, errors.New("some error"))
+
+		assert.Equal(t, "{\"level\":\"warn\",\"key\":\"value\",\"message\":\"warning message: some error\"}\n", out.String())
 	})
 }
 
@@ -102,6 +154,19 @@ func TestZerologAdapter_Info(t *testing.T) {
 	})
 }
 
+func TestZerologAdapter_InfoWithFields(t *testing.T) {
+	t.Run("TestZerologAdapter_InfoWithFields_ShouldLog", func(t *testing.T) {
+		expectedMsg := "info message"
+		expectedFields := map[string]interface{}{
+			"key": "value",
+		}
+		adapter, out := newAdapter()
+		adapter.InfoWithFields(expectedFields, expectedMsg)
+
+		assert.Equal(t, "{\"level\":\"info\",\"key\":\"value\",\"message\":\"info message\"}\n", out.String())
+	})
+}
+
 func TestZerologAdapter_Infof(t *testing.T) {
 	t.Run("TestZerologAdapter_Infof_ShouldLog", func(t *testing.T) {
 		expectedMsg := "info message: %v"
@@ -109,6 +174,19 @@ func TestZerologAdapter_Infof(t *testing.T) {
 		adapter.Infof(expectedMsg, errors.New("some error"))
 
 		assert.Equal(t, "{\"level\":\"info\",\"message\":\"info message: some error\"}\n", out.String())
+	})
+}
+
+func TestZerologAdapter_InfofWithFields(t *testing.T) {
+	t.Run("TestZerologAdapter_InfofWithFields_ShouldLog", func(t *testing.T) {
+		expectedMsg := "info message: %v"
+		expectedFields := map[string]interface{}{
+			"key": "value",
+		}
+		adapter, out := newAdapter()
+		adapter.InfofWithFields(expectedFields, expectedMsg, errors.New("some error"))
+
+		assert.Equal(t, "{\"level\":\"info\",\"key\":\"value\",\"message\":\"info message: some error\"}\n", out.String())
 	})
 }
 
@@ -122,6 +200,19 @@ func TestZerologAdapter_Debug(t *testing.T) {
 	})
 }
 
+func TestZerologAdapter_DebugWithFields(t *testing.T) {
+	t.Run("TestZerologAdapter_DebugWithFields_ShouldLog", func(t *testing.T) {
+		expectedMsg := "debug message"
+		expectedFields := map[string]interface{}{
+			"key": "value",
+		}
+		adapter, out := newAdapter()
+		adapter.DebugWithFields(expectedFields, expectedMsg)
+
+		assert.Equal(t, "{\"level\":\"debug\",\"key\":\"value\",\"message\":\"debug message\"}\n", out.String())
+	})
+}
+
 func TestZerologAdapter_Debugf(t *testing.T) {
 	t.Run("TestZerologAdapter_Debugf_ShouldLog", func(t *testing.T) {
 		expectedMsg := "debug message: %v"
@@ -129,6 +220,19 @@ func TestZerologAdapter_Debugf(t *testing.T) {
 		adapter.Debugf(expectedMsg, errors.New("some error"))
 
 		assert.Equal(t, "{\"level\":\"debug\",\"message\":\"debug message: some error\"}\n", out.String())
+	})
+}
+
+func TestZerologAdapter_DebugfWithFields(t *testing.T) {
+	t.Run("TestZerologAdapter_DebugfWithFields_ShouldLog", func(t *testing.T) {
+		expectedMsg := "debug message: %v"
+		expectedFields := map[string]interface{}{
+			"key": "value",
+		}
+		adapter, out := newAdapter()
+		adapter.DebugfWithFields(expectedFields, expectedMsg, errors.New("some error"))
+
+		assert.Equal(t, "{\"level\":\"debug\",\"key\":\"value\",\"message\":\"debug message: some error\"}\n", out.String())
 	})
 }
 

--- a/adapter/zlog/example/main.go
+++ b/adapter/zlog/example/main.go
@@ -16,15 +16,26 @@ func main() {
 
 func doSomething(l logger.Logger) {
 	err := errors.New("some error")
+	fields := map[string]interface{}{
+		"key": "value",
+	}
 
 	l.Error("a meaningful std message")
+	l.ErrorWithFields(fields, "a meaningful std message")
 	l.Errorf("a meaningful std message: %v", err)
+	l.ErrorfWithFields(fields, "a meaningful std message: %v", err)
 	l.ErrorErr(err)
 	l.Warn("a meaningful std message")
+	l.WarnWithFields(fields, "a meaningful std message")
 	l.Warnf("a meaningful std message: %v", err)
+	l.WarnfWithFields(fields, "a meaningful std message: %v", err)
 	l.WarnErr(err)
 	l.Info("a meaningful std message")
+	l.InfoWithFields(fields, "a meaningful std message")
 	l.Infof("a meaningful std message: %v", err)
+	l.InfofWithFields(fields, "a meaningful std message: %v", err)
 	l.Debug("a meaningful std message")
+	l.DebugWithFields(fields, "a meaningful std message")
 	l.Debugf("a meaningful std message: %v", err)
+	l.DebugfWithFields(fields, "a meaningful std message: %v", err)
 }

--- a/logger.go
+++ b/logger.go
@@ -2,13 +2,21 @@ package logger
 
 type Logger interface {
 	Error(msg string)
+	ErrorWithFields(fields map[string]interface{}, msg string)
 	Errorf(format string, v ...interface{})
+	ErrorfWithFields(fields map[string]interface{}, format string, v ...interface{})
 	ErrorErr(err error)
 	Warn(msg string)
+	WarnWithFields(fields map[string]interface{}, msg string)
 	Warnf(format string, v ...interface{})
+	WarnfWithFields(fields map[string]interface{}, format string, v ...interface{})
 	WarnErr(err error)
 	Info(msg string)
+	InfoWithFields(fields map[string]interface{}, msg string)
 	Infof(format string, v ...interface{})
+	InfofWithFields(fields map[string]interface{}, format string, v ...interface{})
 	Debug(msg string)
+	DebugWithFields(fields map[string]interface{}, msg string)
 	Debugf(format string, v ...interface{})
+	DebugfWithFields(fields map[string]interface{}, format string, v ...interface{})
 }

--- a/mock/logger.go
+++ b/mock/logger.go
@@ -16,8 +16,16 @@ func (m *LoggerMock) Error(msg string) {
 	m.Called(msg)
 }
 
+func (m *LoggerMock) ErrorWithFields(fields map[string]interface{}, msg string) {
+	m.Called(fields, msg)
+}
+
 func (m *LoggerMock) Errorf(format string, v ...interface{}) {
 	m.Called(format, v)
+}
+
+func (m *LoggerMock) ErrorfWithFields(fields map[string]interface{}, format string, v ...interface{}) {
+	m.Called(fields, format, v)
 }
 
 func (m *LoggerMock) ErrorErr(err error) {
@@ -28,8 +36,16 @@ func (m *LoggerMock) Warn(msg string) {
 	m.Called(msg)
 }
 
+func (m *LoggerMock) WarnWithFields(fields map[string]interface{}, msg string) {
+	m.Called(fields, msg)
+}
+
 func (m *LoggerMock) Warnf(format string, v ...interface{}) {
 	m.Called(format, v)
+}
+
+func (m *LoggerMock) WarnfWithFields(fields map[string]interface{}, format string, v ...interface{}) {
+	m.Called(fields, format, v)
 }
 
 func (m *LoggerMock) WarnErr(err error) {
@@ -40,14 +56,30 @@ func (m *LoggerMock) Info(msg string) {
 	m.Called(msg)
 }
 
+func (m *LoggerMock) InfoWithFields(fields map[string]interface{}, msg string) {
+	m.Called(fields, msg)
+}
+
 func (m *LoggerMock) Infof(format string, v ...interface{}) {
 	m.Called(format, v)
+}
+
+func (m *LoggerMock) InfofWithFields(fields map[string]interface{}, format string, v ...interface{}) {
+	m.Called(fields, format, v)
 }
 
 func (m *LoggerMock) Debug(msg string) {
 	m.Called(msg)
 }
 
+func (m *LoggerMock) DebugWithFields(fields map[string]interface{}, msg string) {
+	m.Called(fields, msg)
+}
+
 func (m *LoggerMock) Debugf(format string, v ...interface{}) {
 	m.Called(format, v)
+}
+
+func (m *LoggerMock) DebugfWithFields(fields map[string]interface{}, format string, v ...interface{}) {
+	m.Called(fields, format, v)
 }

--- a/wrapper.go
+++ b/wrapper.go
@@ -14,8 +14,16 @@ func (l *loggerWrapper) Error(msg string) {
 	l.innerLogger.Error(msg)
 }
 
+func (l *loggerWrapper) ErrorWithFields(fields map[string]interface{}, msg string) {
+	l.innerLogger.ErrorWithFields(fields, msg)
+}
+
 func (l *loggerWrapper) Errorf(format string, v ...interface{}) {
 	l.innerLogger.Errorf(format, v...)
+}
+
+func (l *loggerWrapper) ErrorfWithFields(fields map[string]interface{}, format string, v ...interface{}) {
+	l.innerLogger.ErrorfWithFields(fields, format, v...)
 }
 
 func (l *loggerWrapper) ErrorErr(err error) {
@@ -26,8 +34,16 @@ func (l *loggerWrapper) Warn(msg string) {
 	l.innerLogger.Warn(msg)
 }
 
+func (l *loggerWrapper) WarnWithFields(fields map[string]interface{}, msg string) {
+	l.innerLogger.WarnWithFields(fields, msg)
+}
+
 func (l *loggerWrapper) Warnf(format string, v ...interface{}) {
 	l.innerLogger.Warnf(format, v...)
+}
+
+func (l *loggerWrapper) WarnfWithFields(fields map[string]interface{}, format string, v ...interface{}) {
+	l.innerLogger.WarnfWithFields(fields, format, v...)
 }
 
 func (l *loggerWrapper) WarnErr(err error) {
@@ -38,14 +54,30 @@ func (l *loggerWrapper) Info(msg string) {
 	l.innerLogger.Info(msg)
 }
 
+func (l *loggerWrapper) InfoWithFields(fields map[string]interface{}, msg string) {
+	l.innerLogger.InfoWithFields(fields, msg)
+}
+
 func (l *loggerWrapper) Infof(format string, v ...interface{}) {
 	l.innerLogger.Infof(format, v...)
+}
+
+func (l *loggerWrapper) InfofWithFields(fields map[string]interface{}, format string, v ...interface{}) {
+	l.innerLogger.InfofWithFields(fields, format, v...)
 }
 
 func (l *loggerWrapper) Debug(msg string) {
 	l.innerLogger.Debug(msg)
 }
 
+func (l *loggerWrapper) DebugWithFields(fields map[string]interface{}, msg string) {
+	l.innerLogger.DebugWithFields(fields, msg)
+}
+
 func (l *loggerWrapper) Debugf(format string, v ...interface{}) {
 	l.innerLogger.Debugf(format, v...)
+}
+
+func (l *loggerWrapper) DebugfWithFields(fields map[string]interface{}, format string, v ...interface{}) {
+	l.innerLogger.DebugfWithFields(fields, format, v...)
 }

--- a/wrapper_test.go
+++ b/wrapper_test.go
@@ -28,6 +28,21 @@ func TestLogger_Error(t *testing.T) {
 	})
 }
 
+func TestLogger_ErrorWithFields(t *testing.T) {
+	t.Run("TestLogger_ErrorWithFields_ShouldCallMock", func(t *testing.T) {
+		innerLogger := mock.NewLoggerMock()
+		logger := NewWrapper(innerLogger)
+
+		expectedFields := map[string]interface{}{
+			"key": "value",
+		}
+		expectedMsg := "error message"
+		innerLogger.On("ErrorWithFields", expectedFields, expectedMsg)
+
+		logger.ErrorWithFields(expectedFields, expectedMsg)
+	})
+}
+
 func TestLogger_Errorf(t *testing.T) {
 	t.Run("TestLogger_Errorf_ShouldCallMock", func(t *testing.T) {
 		innerLogger := mock.NewLoggerMock()
@@ -38,6 +53,22 @@ func TestLogger_Errorf(t *testing.T) {
 		innerLogger.On("Errorf", expectedMsg, []interface{}{expectedErr})
 
 		logger.Errorf(expectedMsg, expectedErr)
+	})
+}
+
+func TestLogger_ErrorfWithFields(t *testing.T) {
+	t.Run("TestLogger_ErrorfWithFields_ShouldCallMock", func(t *testing.T) {
+		innerLogger := mock.NewLoggerMock()
+		logger := NewWrapper(innerLogger)
+
+		expectedFields := map[string]interface{}{
+			"key": "value",
+		}
+		expectedMsg := "error message: %v"
+		expectedErr := errors.New("some error")
+		innerLogger.On("ErrorfWithFields", expectedFields, expectedMsg, []interface{}{expectedErr})
+
+		logger.ErrorfWithFields(expectedFields, expectedMsg, expectedErr)
 	})
 }
 
@@ -65,6 +96,21 @@ func TestLogger_Warn(t *testing.T) {
 	})
 }
 
+func TestLogger_WarnWithFields(t *testing.T) {
+	t.Run("TestLogger_WarnWithFields_ShouldCallMock", func(t *testing.T) {
+		innerLogger := mock.NewLoggerMock()
+		logger := NewWrapper(innerLogger)
+
+		expectedFields := map[string]interface{}{
+			"key": "value",
+		}
+		expectedMsg := "warning message"
+		innerLogger.On("WarnWithFields", expectedFields, expectedMsg)
+
+		logger.WarnWithFields(expectedFields, expectedMsg)
+	})
+}
+
 func TestLogger_Warnf(t *testing.T) {
 	t.Run("TestLogger_Warnf_ShouldCallMock", func(t *testing.T) {
 		innerLogger := mock.NewLoggerMock()
@@ -75,6 +121,22 @@ func TestLogger_Warnf(t *testing.T) {
 		innerLogger.On("Warnf", expectedMsg, []interface{}{expectedErr})
 
 		logger.Warnf(expectedMsg, expectedErr)
+	})
+}
+
+func TestLogger_WarnfWithFields(t *testing.T) {
+	t.Run("TestLogger_WarnfWithFields_ShouldCallMock", func(t *testing.T) {
+		innerLogger := mock.NewLoggerMock()
+		logger := NewWrapper(innerLogger)
+
+		expectedFields := map[string]interface{}{
+			"key": "value",
+		}
+		expectedMsg := "warning message: %v"
+		expectedErr := errors.New("some error")
+		innerLogger.On("WarnfWithFields", expectedFields, expectedMsg, []interface{}{expectedErr})
+
+		logger.WarnfWithFields(expectedFields, expectedMsg, expectedErr)
 	})
 }
 
@@ -102,6 +164,21 @@ func TestLogger_Info(t *testing.T) {
 	})
 }
 
+func TestLogger_InfoWithFields(t *testing.T) {
+	t.Run("TestLogger_InfoWithFields_ShouldCallMock", func(t *testing.T) {
+		innerLogger := mock.NewLoggerMock()
+		logger := NewWrapper(innerLogger)
+
+		expectedFields := map[string]interface{}{
+			"key": "value",
+		}
+		expectedMsg := "info message"
+		innerLogger.On("InfoWithFields", expectedFields, expectedMsg)
+
+		logger.InfoWithFields(expectedFields, expectedMsg)
+	})
+}
+
 func TestLogger_Infof(t *testing.T) {
 	t.Run("TestLogger_Infof_ShouldCallMock", func(t *testing.T) {
 		innerLogger := mock.NewLoggerMock()
@@ -112,6 +189,22 @@ func TestLogger_Infof(t *testing.T) {
 		innerLogger.On("Infof", expectedMsg, []interface{}{expectedErr})
 
 		logger.Infof(expectedMsg, expectedErr)
+	})
+}
+
+func TestLogger_InfofWithFields(t *testing.T) {
+	t.Run("TestLogger_InfofWithFields_ShouldCallMock", func(t *testing.T) {
+		innerLogger := mock.NewLoggerMock()
+		logger := NewWrapper(innerLogger)
+
+		expectedFields := map[string]interface{}{
+			"key": "value",
+		}
+		expectedMsg := "info message: %v"
+		expectedErr := errors.New("some error")
+		innerLogger.On("InfofWithFields", expectedFields, expectedMsg, []interface{}{expectedErr})
+
+		logger.InfofWithFields(expectedFields, expectedMsg, expectedErr)
 	})
 }
 
@@ -127,6 +220,21 @@ func TestLogger_Debug(t *testing.T) {
 	})
 }
 
+func TestLogger_DebugWithFields(t *testing.T) {
+	t.Run("TestLogger_DebugWithFields_ShouldCallMock", func(t *testing.T) {
+		innerLogger := mock.NewLoggerMock()
+		logger := NewWrapper(innerLogger)
+
+		expectedFields := map[string]interface{}{
+			"key": "value",
+		}
+		expectedMsg := "debug message"
+		innerLogger.On("DebugWithFields", expectedFields, expectedMsg)
+
+		logger.DebugWithFields(expectedFields, expectedMsg)
+	})
+}
+
 func TestLogger_Debugf(t *testing.T) {
 	t.Run("TestLogger_Debugf_ShouldCallMock", func(t *testing.T) {
 		innerLogger := mock.NewLoggerMock()
@@ -137,5 +245,21 @@ func TestLogger_Debugf(t *testing.T) {
 		innerLogger.On("Debugf", expectedMsg, []interface{}{expectedErr})
 
 		logger.Debugf(expectedMsg, expectedErr)
+	})
+}
+
+func TestLogger_DebugfWithFields(t *testing.T) {
+	t.Run("TestLogger_DebugfWithFields_ShouldCallMock", func(t *testing.T) {
+		innerLogger := mock.NewLoggerMock()
+		logger := NewWrapper(innerLogger)
+
+		expectedFields := map[string]interface{}{
+			"key": "value",
+		}
+		expectedMsg := "debug message: %v"
+		expectedErr := errors.New("some error")
+		innerLogger.On("DebugfWithFields", expectedFields, expectedMsg, []interface{}{expectedErr})
+
+		logger.DebugfWithFields(expectedFields, expectedMsg, expectedErr)
 	})
 }


### PR DESCRIPTION
The current interface only routes pure message logging calls to the underlying logger implementation.

This PR extends the logger interface with new methods that take an additional context parameter of type `map[string]interface{}`. The logging context is converted if needed and then passed to the underlying logger implementation.